### PR TITLE
Move Studio Assets to Vendor Folder

### DIFF
--- a/resources/stubs/views/app.stub
+++ b/resources/stubs/views/app.stub
@@ -19,7 +19,7 @@
     <title>{{ config('app.name') }}</title>
 
     <link rel="canonical">
-    <link href="{{ mix('studio/css/app.css') }}" rel="stylesheet">
+    <link href="{{ mix('studio.css') }}" rel="stylesheet">
 
     <link rel="dns-prefetch" href="//fonts.gstatic.com">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Karla|Merriweather:400,700">
@@ -36,6 +36,6 @@
     window.Studio = @json($scripts);
 </script>
 
-<script src="{{ asset('studio/js/app.js') }}" defer></script>
+<script src="{{ asset('studio.js') }}" defer></script>
 </body>
 </html>

--- a/resources/stubs/webpack.stub
+++ b/resources/stubs/webpack.stub
@@ -1,3 +1,3 @@
 
-mix.js('resources/js/studio/app.js', 'public/studio/js')
-    .sass('resources/sass/studio/app.scss', 'public/studio/css');
+mix.js('resources/js/studio/app.js', 'public/studio.js')
+    .sass('resources/sass/studio/app.scss', 'public/studio.css');


### PR DESCRIPTION
This PR aims to fix the 403 issues some users have been experiencing (#11) when using Apache by moving the `/public/studio` directory inside the `/public/vendor` directory.